### PR TITLE
Fix path for roofline plot generation.

### DIFF
--- a/gemmbench/gemm_bench.py
+++ b/gemmbench/gemm_bench.py
@@ -73,7 +73,7 @@ if __name__ == "__main__":
 
     if args.roofline:
         for dtype in requested_dtypes:
-            roofline(args.roofline, f"{args.plot.split(".")[0]}_{dtype}.png", args.batch, dtype, args.model)
+            roofline(args.roofline, f"{args.plot.split('.')[0]}_{dtype}.png", args.batch, dtype, args.model)
         sys.exit()
 
     tk = args.tk

--- a/gemmbench/gemm_bench.py
+++ b/gemmbench/gemm_bench.py
@@ -73,7 +73,7 @@ if __name__ == "__main__":
 
     if args.roofline:
         for dtype in requested_dtypes:
-            roofline(args.roofline, f"{args.plot}_{dtype}", args.batch, dtype, args.model)
+            roofline(args.roofline, f"{args.plot.split(".")[0]}_{dtype}.png", args.batch, dtype, args.model)
         sys.exit()
 
     tk = args.tk


### PR DESCRIPTION
This commit fixes the path for roofline plot generation, so we don't try to add a dtype string after the file extension.