### PR TITLE
Adapt to iree-turbine naming changes.

### DIFF
--- a/.github/workflows/run_bench.yml
+++ b/.github/workflows/run_bench.yml
@@ -30,7 +30,7 @@ jobs:
           pip install --find-links https://iree.dev/pip-release-links.html iree-compiler iree-runtime --upgrade
           pip install -r requirements.txt
           pip install --no-compile --pre --upgrade -e common_tools
-          pip install shark-turbine@git+https://github.com/iree-org/iree-turbine.git@main
+          pip install iree-turbine@git+https://github.com/iree-org/iree-turbine.git@main
 
       - name: Convolutions
         run: |

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ python3.11 -m venv bench_venv
 source bench_venv/bin/activate
 pip install -r requirements.txt
 pip install --no-compile --pre --upgrade -e common_tools
-pip install shark-turbine@git+https://github.com/iree-org/iree-turbine.git@main
+pip install iree-turbine@git+https://github.com/iree-org/iree-turbine.git@main
 ```
 
 ## Performance

--- a/gemmbench/gemm_utils.py
+++ b/gemmbench/gemm_utils.py
@@ -2,10 +2,10 @@ from utils import *
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
-import shark_turbine.kernel as tk
-import shark_turbine.kernel.lang as tkl
-import shark_turbine.kernel.wave as tkw
-from shark_turbine.kernel.lang.global_symbols import *
+import iree.turbine.kernel as tk
+import iree.turbine.kernel.lang as tkl
+import iree.turbine.kernel.wave as tkw
+from iree.turbine.kernel.lang.global_symbols import *
 import torch
 
 @dataclass


### PR DESCRIPTION
This commit adapts to the recent changes made to the packaging naming in the iree-org/iree-turbine repo: https://github.com/iree-org/iree-turbine/pull/197