### PR TITLE
Adds arg for exec file dump dir, instruction counter script

### DIFF
--- a/common_tools/instruction_count.py
+++ b/common_tools/instruction_count.py
@@ -12,7 +12,7 @@ def count_instr_in_file(file_path):
             if "Kernarg preload header" in line:
                 counting = True
             # End when "---" is read
-            elif "---" in line and counting:
+            elif "s_endpgm" in line and counting:
                 break
             if counting:
                 instr_count += 1
@@ -40,14 +40,14 @@ def write_results_to_csv(results, output_file):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Data collection tool targeting HSA dumps.")
-    parser.add_argument("--search_dir", help="The directory from which to scan for ISA file dumps (.rocmasm).", type=str, default=None)
+    parser.add_argument("dir", help="The directory from which to scan for ISA file dumps (.rocmasm).", type=str, default=None)
     args = parser.parse_args()
     output_file = 'rocmasm_instr_counts.csv'
 
-    results = search_directory(args.search_dir)
+    results = search_directory(args.dir)
 
     if results:
         write_results_to_csv(results, output_file)
-        print(f"Results written to {output_file}")
+        print(f"\nResults written to {output_file}")
     else:
-        print("No .rocmasm files found.")
+        print("\nNo .rocmasm files found.")

--- a/common_tools/instruction_count.py
+++ b/common_tools/instruction_count.py
@@ -1,0 +1,53 @@
+import os
+import argparse
+import csv
+
+def count_instr_in_file(file_path):
+    counting = False
+    instr_count = 0
+    
+    with open(file_path, 'r', encoding='utf-8', errors='ignore') as file:
+        for line in file:
+            # Start counting when "Kernarg preload header" is read
+            if "Kernarg preload header" in line:
+                counting = True
+            # End when "---" is read
+            elif "---" in line and counting:
+                break
+            if counting:
+                instr_count += 1
+    return instr_count
+
+def search_directory(directory):
+    """Search for .rocmasm files and count their lines."""
+    results = []
+    for root, _, files in os.walk(directory):
+        for file in files:
+            if file.endswith('.rocmasm'):
+                file_path = os.path.join(root, file)
+                line_count = count_instr_in_file(file_path)
+                results.append((file_path, line_count))
+    return results
+
+def write_results_to_csv(results, output_file):
+    """Write the results to a CSV file."""
+    # Sort results by line count (second item in tuple)
+    results.sort(key=lambda x: x[1], reverse=True)
+    with open(output_file, 'w', newline='', encoding='utf-8') as csvfile:
+        csv_writer = csv.writer(csvfile)
+        csv_writer.writerow(['Filename', 'Instruction Count'])
+        csv_writer.writerows(results)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Data collection tool targeting HSA dumps.")
+    parser.add_argument("--search_dir", help="The directory from which to scan for ISA file dumps (.rocmasm).", type=str, default=None)
+    args = parser.parse_args()
+    output_file = 'rocmasm_instr_counts.csv'
+
+    results = search_directory(args.search_dir)
+
+    if results:
+        write_results_to_csv(results, output_file)
+        print(f"Results written to {output_file}")
+    else:
+        print("No .rocmasm files found.")

--- a/common_tools/instruction_count.py
+++ b/common_tools/instruction_count.py
@@ -3,14 +3,11 @@ import argparse
 import csv
 
 def count_instr_in_file(file_path):
-    instr_count = 0
-    
     with open(file_path, 'r', encoding='utf-8', errors='ignore') as file:
-        for line in file:
+        for idx, line in enumerate(file):
             if "s_endpgm" in line:
-                break
-            instr_count += 1
-    return instr_count
+               return idx
+    return -1
 
 def search_directory(directory):
     """Search for .rocmasm files and count their lines."""

--- a/common_tools/instruction_count.py
+++ b/common_tools/instruction_count.py
@@ -3,19 +3,13 @@ import argparse
 import csv
 
 def count_instr_in_file(file_path):
-    counting = False
     instr_count = 0
     
     with open(file_path, 'r', encoding='utf-8', errors='ignore') as file:
         for line in file:
-            # Start counting when "Kernarg preload header" is read
-            if "Kernarg preload header" in line:
-                counting = True
-            # End when "---" is read
-            elif "s_endpgm" in line and counting:
+            if "s_endpgm" in line:
                 break
-            if counting:
-                instr_count += 1
+            instr_count += 1
     return instr_count
 
 def search_directory(directory):
@@ -48,6 +42,6 @@ if __name__ == "__main__":
 
     if results:
         write_results_to_csv(results, output_file)
-        print(f"\nResults written to {output_file}")
+        print(f"Results written to {output_file} \n")
     else:
-        print("\nNo .rocmasm files found.")
+        print("No .rocmasm files found. \n")

--- a/common_tools/instruction_count.py
+++ b/common_tools/instruction_count.py
@@ -42,6 +42,6 @@ if __name__ == "__main__":
 
     if results:
         write_results_to_csv(results, output_file)
-        print(f"Results written to {output_file} \n")
+        print(f"Results written to {output_file}\n")
     else:
-        print("No .rocmasm files found. \n")
+        print("No .rocmasm files found.\n")

--- a/gemmbench/gemm_bench.py
+++ b/gemmbench/gemm_bench.py
@@ -18,10 +18,10 @@ from gemm_utils import *
 from problems import get_gemm_configs, get_tk_gemm_configs, get_matching_configs
 
 
-def compile_gemm(tag, config, kernel_dir, vmfb_dir, target, extra_compiler_args, tk, exec_dump_dir=None):
-    if exec_dump_dir:
+def compile_gemm(tag, config, kernel_dir, vmfb_dir, target, extra_compiler_args, tk, dump_dir=None):
+    if dump_dir:
         name = config.get_name()
-        dpath = os.path.join(exec_dump_dir, name)
+        dpath = os.path.join(dump_dir, name)
         extra_compiler_args.extend([
             f"--iree-hal-dump-executable-files-to={dpath}"
         ])
@@ -70,7 +70,7 @@ if __name__ == "__main__":
         help="Run gemm kernels using Turbine Kernels",
     )
     parser.add_argument(
-        "--exec_dump_dir",
+        "--dump_dir",
         type=str,
         default=None,
         help="Directory to which executable files will be dumped."
@@ -106,10 +106,10 @@ if __name__ == "__main__":
     vmfb_dir.mkdir(parents=True, exist_ok=True)
     target = args.target
     extra_compiler_args = list(args.Xiree_compile)
-    exec_dump_dir = args.exec_dump_dir
+    dump_dir = args.dump_dir
     
     args = itertools.starmap(
-        lambda tag, config: (tag, config, kernel_dir, vmfb_dir, target, extra_compiler_args, tk, exec_dump_dir), configs
+        lambda tag, config: (tag, config, kernel_dir, vmfb_dir, target, extra_compiler_args, tk, dump_dir), configs
     )
     with Pool(num_cpus) as pool:
         compilation_results = list(tqdm(pool.starmap(compile_gemm, list(args))))


### PR DESCRIPTION
Adds the --exec_dump_dir flag to the gemmbench script and creates a script for generating a .csv with instruction counts (naive) from dumped .rocmasm files.

By naive, I mean it starts counting lines at "Kernarg preload header" and stops at "---" to count instructions.
@kuhar is the stopping criteria here too late? it includes what seems to be metadata, so maybe it should stop at "s_endpgm" or "func_end0"?

Perhaps some of the counter utilities should be further integrated into the benchmarking tooling.

The instruction counter generates a file like this (also attached):
```
Filename,Instruction Count
./dumps/gemm_4096_640_2560_bf16/module_main_dispatch_0_rocm_hsaco_fb.rocmasm,1074
./dumps/gemm_4096_5120_640_f16_tB/module_main_dispatch_0_rocm_hsaco_fb.rocmasm,1074
./dumps/gemm_8192_640_2560_bf16/module_main_dispatch_0_rocm_hsaco_fb.rocmasm,1074
./dumps/gemm_1024_1280_1280_bf16/module_main_dispatch_0_rocm_hsaco_fb.rocmasm,1067
./dumps/gemm_2048_1280_1280_bf16/module_main_dispatch_0_rocm_hsaco_fb.rocmasm,1067
./dumps/gemm_1024_10240_1280_bf16/module_main_dispatch_0_rocm_hsaco_fb.rocmasm,1064
./dumps/gemm_128_1280_2048_bf16/module_main_dispatch_0_rocm_hsaco_fb.rocmasm,1064
./dumps/gemm_64_640_2048_bf16/module_main_dispatch_0_rocm_hsaco_fb.rocmasm,1064
./dumps/gemm_4096_4096_8192_f16_tB/module_main_dispatch_0_rocm_hsaco_fb.rocmasm,1034
./dumps/gemm_1024_1280_5120_bf16_tB/module_main_dispatch_0_rocm_hsaco_fb.rocmasm,1003
./dumps/gemm_4096_4096_8192_bf16/module_main_dispatch_0_rocm_hsaco_fb.rocmasm,997
./dumps/gemm_64_1280_2048_bf16_tB/module_main_dispatch_0_rocm_hsaco_fb.rocmasm,997
./dumps/gemm_2048_10240_1280_bf16_tB/module_main_dispatch_0_rocm_hsaco_fb.rocmasm,997
./dumps/gemm_2048_1280_5120_bf16_tB/module_main_dispatch_0_rocm_hsaco_fb.rocmasm,993
./dumps/gemm_8192_640_640_bf16_tB/module_main_dispatch_0_rocm_hsaco_fb.rocmasm,993
./dumps/gemm_4096_640_640_bf16_tB/module_main_dispatch_0_rocm_hsaco_fb.rocmasm,993
./dumps/gemm_8192_5120_640_bf16_tB/module_main_dispatch_0_rocm_hsaco_fb.rocmasm,983
./dumps/gemm_4096_640_2560_f16/module_main_dispatch_0_rocm_hsaco_fb.rocmasm,931
./dumps/gemm_8192_640_2560_f16/module_main_dispatch_0_rocm_hsaco_fb.rocmasm,931
./dumps/gemm_4096_4096_8192_bf16_tA/module_main_dispatch_0_rocm_hsaco_fb.rocmasm,929
./dumps/gemm_1024_1280_1280_f16/module_main_dispatch_0_rocm_hsaco_fb.rocmasm,914
./dumps/gemm_2048_1280_1280_f16/module_main_dispatch_0_rocm_hsaco_fb.rocmasm,914
./dumps/gemm_2048_2048_65536_f16/module_main_dispatch_0_rocm_hsaco_fb.rocmasm,909
./dumps/gemm_2048_8192_8192_f16/module_main_dispatch_0_rocm_hsaco_fb.rocmasm,909
./dumps/gemm_8192_8192_8192_f16/module_main_dispatch_0_rocm_hsaco_fb.rocmasm,909
./dumps/gemm_8192_2048_65536_f16/module_main_dispatch_0_rocm_hsaco_fb.rocmasm,909
./dumps/gemm_2_7168_8192_bf16_tB/module_main_dispatch_0_rocm_hsaco_fb.rocmasm,908
./dumps/gemm_2048_2048_1024_f16/module_main_dispatch_0_rocm_hsaco_fb.rocmasm,901
./dumps/gemm_8192_2048_1024_f16/module_main_dispatch_0_rocm_hsaco_fb.rocmasm,901
./dumps/gemm_128_1280_2048_f16/module_main_dispatch_0_rocm_hsaco_fb.rocmasm,899
./dumps/gemm_1024_10240_1280_f16/module_main_dispatch_0_rocm_hsaco_fb.rocmasm,899
./dumps/gemm_5120_8_3456_f16_tA/module_main_dispatch_0_rocm_hsaco_fb.rocmasm,890
./dumps/gemm_3456_8_5120_f16_tA/module_main_dispatch_0_rocm_hsaco_fb.rocmasm,890
./dumps/gemm_7680_8_5120_f16_tA/module_main_dispatch_0_rocm_hsaco_fb.rocmasm,890
./dumps/gemm_8000_8_8192_f16_tA/module_main_dispatch_0_rocm_hsaco_fb.rocmasm,890
./dumps/gemm_1920_8_5120_f16_tA/module_main_dispatch_0_rocm_hsaco_fb.rocmasm,890
./dumps/gemm_5120_8_8192_f16_tA/module_main_dispatch_0_rocm_hsaco_fb.rocmasm,890
<truncated>
```
[rocmasm_line_counts.csv](https://github.com/user-attachments/files/17280511/rocmasm_line_counts.csv)
