### PR TITLE
Fix accumulator and result types

### DIFF
--- a/gemmbench/gemm_bench.py
+++ b/gemmbench/gemm_bench.py
@@ -171,7 +171,7 @@ if __name__ == "__main__":
         tflops_per_second = (flops / 1e12) / (benchmark_gemm_mean_time_us / 1e6)
 
         results.append((
-            index, tag, name, vmfb_hash, config.M, config.N, config.K, config.dtype, config.tA, config.tB,
+            index, tag, name, vmfb_hash, config.M, config.N, config.K, config.operand_element_type, config.tA, config.tB,
             round(benchmark_gemm_mean_time_us, 4),
             round(arithmetic_intensity, 4),
             round(tflops_per_second, 4),

--- a/gemmbench/gemm_bench.py
+++ b/gemmbench/gemm_bench.py
@@ -107,7 +107,7 @@ if __name__ == "__main__":
     target = args.target
     extra_compiler_args = list(args.Xiree_compile)
     dump_dir = args.dump_dir
-    
+
     args = itertools.starmap(
         lambda tag, config: (tag, config, kernel_dir, vmfb_dir, target, extra_compiler_args, tk, dump_dir), configs
     )

--- a/gemmbench/gemm_utils.py
+++ b/gemmbench/gemm_utils.py
@@ -116,7 +116,10 @@ module {{
         return mlir_template_B
     return mlir_template
 
+
 def generate_tk_mlir(config: GemmConfig):
+    assert config.operand_element_type == 'f16', "Unsupported problem"
+    assert config.accumulator_element_type == 'f32', "Unsupported problem"
     # Input sizes
     M = tkl.sym.M
     N = tkl.sym.N

--- a/gemmbench/gemm_utils.py
+++ b/gemmbench/gemm_utils.py
@@ -195,9 +195,9 @@ def generate_tk_mlir(config: GemmConfig):
     with tk.gen.TestLaunchContext(
         hyperparams, canonicalize=True, run=True, run_config=config
     ):
-        a = torch.randn(shape[0], shape[2], operand_element_type=operand_element_type)
-        b = torch.randn(shape[1], shape[2], operand_element_type=operand_element_type)
-        c = torch.zeros(shape[0], shape[1], operand_element_type=torch.float32)
+        a = torch.randn(shape[0], shape[2], dtype=operand_element_type)
+        b = torch.randn(shape[1], shape[2], dtype=operand_element_type)
+        c = torch.zeros(shape[0], shape[1], dtype=torch.float32)
         mb = gemm(a, b, c)
 
         return mb.module_op.get_asm()

--- a/gemmbench/problems.py
+++ b/gemmbench/problems.py
@@ -1011,7 +1011,7 @@ def get_matching_configs(
     tag_re = re.compile(tag_regex)
     matching_configs: list[tuple[str, GemmConfig]] = []
     for tag, config in tagged_configs:
-        if config.dtype not in dtypes:
+        if config.operand_element_type not in dtypes:
             continue
         if f"{config.tA}{config.tB}" not in variants:
             continue


### PR DESCRIPTION
For example, perform f16 matmul with f32 as the accumulator type and truncate the result to f16. This is more realistic than using f16 as the accumulator type.

Keep track of operand, accumulator, and result types in `GemmConfig`.