### PR TITLE
Fix TKW gemm tests

### DIFF
--- a/gemmbench/gemm_bench.py
+++ b/gemmbench/gemm_bench.py
@@ -158,12 +158,14 @@ if __name__ == "__main__":
             f"--device={device}",
             "--device_allocator=caching",
             f"--module={vmfb_filename}",
+            "--benchmark_repetitions=3",
             f"--input={inp1}",
             f"--input={inp2}",
-            "--benchmark_repetitions=3",
         ]
 
         if tk:
+            out_shape = config.get_out()
+            exec_args.append(f"--input={out_shape}")
             exec_args += ["--function=isolated_benchmark"]
         else:
             exec_args += ["--function=main"]

--- a/gemmbench/gemm_utils.py
+++ b/gemmbench/gemm_utils.py
@@ -258,12 +258,15 @@ def generate_tk_mlir(config: GemmConfig, vmfb_file: Path):
     }
     hyperparams.update(get_default_scheduling_params())
     config = get_default_run_config()
+
+    # TODO: Scheduling is taking too long time with large K.
+    schedule = (config.K < 4096)
     with tk.gen.TestLaunchContext(
         hyperparams,
         canonicalize=True,
         create_vmfb_file=vmfb_file,
         run_config=config,
-        schedule=True,
+        schedule=schedule,
     ):
         mb = gemm()
 

--- a/gemmbench/gemm_utils.py
+++ b/gemmbench/gemm_utils.py
@@ -221,7 +221,7 @@ def generate_tk_mlir(config: GemmConfig, vmfb_file: Path):
     def gemm(
         a: tkl.Memory[M, K, ADDRESS_SPACE, tkl.f16],
         b: tkl.Memory[N, K, ADDRESS_SPACE, tkl.f16],
-        c: tkl.Memory[M, N, GLOBAL_ADDRESS_SPACE, tkl.f32],
+        c: tkl.Memory[M, N, GLOBAL_ADDRESS_SPACE, res_dtype],
     ):
         c_reg = tkl.Register[M, N, tkl.f32](0.0)
 

--- a/gemmbench/gemm_utils.py
+++ b/gemmbench/gemm_utils.py
@@ -266,7 +266,15 @@ def compile_gemm_config(
 
     # Generate mlir content
     if tk:
-        mlir_content = generate_tk_mlir(config, vmfb_file)
+        try:
+            mlir_content = generate_tk_mlir(config, vmfb_file)
+        except Exception as e:
+            error_file = vmfb_dir / (config.get_name() + "_error.txt")
+            print(f"Failed to compile {config.get_name()}. Error dumped in {error_file}")
+            with open(error_file, "w") as f:
+                f.write(str(e))
+                f.write(traceback.format_exc())
+            return mlir_file, None
     else:
         mlir_content = generate_mlir(config)
 

--- a/gemmbench/gemm_utils.py
+++ b/gemmbench/gemm_utils.py
@@ -11,6 +11,7 @@ from iree.turbine.kernel.wave.utils import (
     get_default_scheduling_params,
 )
 import torch
+import traceback
 
 
 @dataclass

--- a/gemmbench/gemm_utils.py
+++ b/gemmbench/gemm_utils.py
@@ -244,6 +244,7 @@ def generate_tk_mlir(config: GemmConfig, vmfb_file: Path):
         tkw.write(repeat, c, elements_per_thread=STORE_ELEMS_PER_THREAD)
 
     shape = [config.M, config.N, config.K]
+    schedule = (config.K < 4096)
 
     hyperparams = {
         ADDRESS_SPACE: SHARED_ADDRESS_SPACE,
@@ -260,7 +261,6 @@ def generate_tk_mlir(config: GemmConfig, vmfb_file: Path):
     config = get_default_run_config()
 
     # TODO: Scheduling is taking too long time with large K.
-    schedule = (config.K < 4096)
     with tk.gen.TestLaunchContext(
         hyperparams,
         canonicalize=True,

--- a/gemmbench/gemm_utils.py
+++ b/gemmbench/gemm_utils.py
@@ -6,6 +6,10 @@ import iree.turbine.kernel as tk
 import iree.turbine.kernel.lang as tkl
 import iree.turbine.kernel.wave as tkw
 from iree.turbine.kernel.lang.global_symbols import *
+from iree.turbine.kernel.wave.utils import (
+    get_default_run_config,
+    get_default_scheduling_params,
+)
 import torch
 
 
@@ -232,16 +236,9 @@ def generate_tk_mlir(config: GemmConfig):
         M: shape[0],
         N: shape[1],
         K: shape[2],
-        READ_SHARED_DELAY: tc.DELAY_SHARED,
-        WRITE_SHARED_DELAY: tc.DELAY_SHARED,
-        READ_GLOBAL_DELAY: tc.DELAY_GLOBAL,
-        WRITE_GLOBAL_DELAY: tc.DELAY_GLOBAL,
-        MMA_DELAY: tc.DELAY_MMA,
-        SHARED_MEMORY_UNITS: tc.SHARED_UNITS,
-        GLOBAL_MEMORY_UNITS: tc.GLOBAL_UNITS,
-        MMA_UNITS: tc.MMA_UNITS,
     }
-    config = {"backend": "rocm", "device": "hip", "target": "gfx942"}
+    hyperparams.update(get_default_scheduling_params())
+    config = get_default_run_config()
     with tk.gen.TestLaunchContext(
         hyperparams, canonicalize=True, run=True, run_config=config, schedule=True,
     ):

--- a/gemmbench/gemm_utils.py
+++ b/gemmbench/gemm_utils.py
@@ -246,7 +246,6 @@ def generate_tk_mlir(config: GemmConfig, vmfb_file: Path):
         hyperparams,
         canonicalize=True,
         create_vmfb_file=vmfb_file,
-        run=True,
         run_config=config,
         schedule=True,
     ):

--- a/gemmbench/gemm_utils.py
+++ b/gemmbench/gemm_utils.py
@@ -258,7 +258,9 @@ def generate_tk_mlir(config: GemmConfig, vmfb_file: Path):
         K: shape[2],
     }
     hyperparams.update(get_default_scheduling_params())
-    config = get_default_run_config()
+    # config = get_default_run_config() TODO: detects device as CPU for some reason
+    config = {"backend": "rocm", "device": "hip", "target": "gfx942"}
+
 
     # TODO: Scheduling is taking too long time with large K.
     with tk.gen.TestLaunchContext(

--- a/gemmbench/gemm_utils.py
+++ b/gemmbench/gemm_utils.py
@@ -288,6 +288,7 @@ def compile_gemm_config(
         try:
             mlir_content = generate_tk_mlir(config, vmfb_file)
         except Exception as e:
+            traceback.print_exc()
             error_file = vmfb_dir / (config.get_name() + "_error.txt")
             print(f"Failed to compile {config.get_name()}. Error dumped in {error_file}")
             with open(error_file, "w") as f:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy
 tqdm
 matplotlib
+torch>=2.3.0


### PR DESCRIPTION
* Use TKW `create_vmfb_file` option to get vmfb file directly
* Get scheduling params from the TK itself
* Disable scheduling for large K as compilation taking too long
* Support case when `out_type` != `accumulator_type`
* Update `exec_args` as code generated by TK expected out param to be present
* Gracefully handle TK errors instead of terminating entire script