### PR TITLE
Allow running GEMM benchmarks without Turbine installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ python3.11 -m venv bench_venv
 source bench_venv/bin/activate
 pip install -r requirements.txt
 pip install --no-compile --pre --upgrade -e common_tools
+```
+
+If you plan to run the TK benchmarks, also install iree-turbine with
+```
 pip install iree-turbine@git+https://github.com/iree-org/iree-turbine.git@main
 ```
 

--- a/gemmbench/gemm_utils.py
+++ b/gemmbench/gemm_utils.py
@@ -1,14 +1,20 @@
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
-import iree.turbine.kernel as tk
-import iree.turbine.kernel.lang as tkl
-import iree.turbine.kernel.wave as tkw
-from iree.turbine.kernel.lang.global_symbols import *
-from iree.turbine.kernel.wave.utils import (
-    get_default_run_config,
-    get_default_scheduling_params,
-)
+try:
+    import iree.turbine.kernel as tk
+    import iree.turbine.kernel.lang as tkl
+    import iree.turbine.kernel.wave as tkw
+    from iree.turbine.kernel.lang.global_symbols import *
+    from iree.turbine.kernel.wave.utils import (
+        get_default_run_config,
+        get_default_scheduling_params,
+    )
+except ImportError:
+    TURBINE_AVAILABLE=False
+else:
+    TURBINE_AVAILABLE=True
+
 from utils import *
 import os
 import traceback
@@ -286,6 +292,8 @@ def compile_gemm_config(
         os.makedirs(vmfb_dir)
 
     # Generate mlir content
+    if tk and not TURBINE_AVAILABLE:
+        raise ValueError("Requested TK benchmarks but Turbine isn't available")
     if tk:
         try:
             mlir_content = generate_tk_mlir(config, vmfb_file)


### PR DESCRIPTION
The convolution benchmarks make TK an optional dependency, not requiring it to be loaded unless you want to run the TK benchmarks.

Update the GEMM benchmarks to work similarly and update the README to make it clear that TK is optional.