### PR TITLE
Pin actions

### DIFF
--- a/.github/workflows/run_bench.yml
+++ b/.github/workflows/run_bench.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: "Checkout Repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup venv
         run: |
@@ -69,7 +69,7 @@ jobs:
           python -m iree_kernel_benchmark.convbench --roofline results/iree_gemm.csv,results/iree_gemm_tk.csv,results/iree_attention.csv,results/iree_conv.csv,results/iree_conv_tk.csv --plot results/combined.png
 
       - name: Upload benchmark results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: benchmark-results
           path: ./results/


### PR DESCRIPTION
Pins actions to a specific version by its hash instead of using a tag as suggested among others by the OpenSSF Scorecard project, see https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies