### PR TITLE
Add pre-commit hooks to do reformatting automatically

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,0 +1,14 @@
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
+    - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b # v5.0.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-added-large-files
+-   repo: https://github.com/psf/black
+    rev: 8a737e727ac5ab2f1d4cf5876720ed276dc8dc4b # 25.1.0
+    hooks:
+    -   id: black

--- a/README.md
+++ b/README.md
@@ -21,13 +21,21 @@ If you plan to run the TK benchmarks, also install iree-turbine with
 pip install iree-turbine@git+https://github.com/iree-org/iree-turbine.git@main
 ```
 
-To run the unit tests for the suite:
+## Development guide
+
+Install the development requirements:
+
+```
+pip install -r dev-requirements.txt
+```
+
+Run the unit tests for the suite:
 
 ```
 pytest
 ```
 
-Please run `black` code formatting before committing.
+This repo uses [`pre-commit`](https://pre-commit.com/) hooks to check code formatting rules. You can run `pre-commit install` to set up the hooks.
 
 ## Performance
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,2 @@
+pytest>=8.3.5
+pre-commit # For pre-commit hooks (code formatting etc)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ numpy
 tqdm
 matplotlib
 torch>=2.3.0
-pytest>=8.3.5
 PyYAML>=6.0.2 # Required by iree.compiler.dialects.linalg


### PR DESCRIPTION
The configuration files have been copied from https://github.com/nod-ai/shark-ai/commit/ba15477766ba5ee2212234e7585012c88c55ab32 but with some version numbers bumped.

This also splits out the development-only PIP requirements, because there's now two packages.