### PR TITLE
Prevent duplicate convbench configs clobbering eachother when compiled

### DIFF
--- a/iree_kernel_benchmark/convbench/__main__.py
+++ b/iree_kernel_benchmark/convbench/__main__.py
@@ -8,6 +8,7 @@ import csv
 import argparse
 import sys
 import re
+from collections import OrderedDict
 from ..utils import *
 from .conv_utils import *
 from .problems import get_conv_configs, get_tk_conv_configs, get_conv_test_configs
@@ -17,14 +18,14 @@ from .wave_conv_utils import compile_wave_conv_config
 
 def compile_conv_iree(tag, config, kernel_dir, vmfb_dir, extra_compiler_args):
     mlir_file, vmfb_file, dump_path = compile_conv_config(
-        config, kernel_dir, vmfb_dir, extra_compiler_args
+        tag, config, kernel_dir, vmfb_dir, extra_compiler_args
     )
     return (tag, config, mlir_file, vmfb_file, dump_path)
 
 
 def compile_conv_wave(tag, config, kernel_dir, vmfb_dir, extra_compiler_args):
     mlir_file, vmfb_file, dump_path = compile_wave_conv_config(
-        config, kernel_dir, vmfb_dir, extra_compiler_args
+        tag, config, kernel_dir, vmfb_dir, extra_compiler_args
     )
     return (tag, config, mlir_file, vmfb_file, dump_path)
 
@@ -82,6 +83,9 @@ if __name__ == "__main__":
     # configs = get_conv_test_configs()
     configs = get_tk_conv_configs() if args.tk else get_conv_configs()
     print(f"Generated {len(configs)} conv configs.")
+
+    configs = list(OrderedDict({config: None for config in configs}))
+    print(f"Deduplicated to {len(configs)} conv configs.")
 
     if args.filter_config is not None:
         filter_regex = re.compile(args.filter_config)

--- a/iree_kernel_benchmark/convbench/conv_utils.py
+++ b/iree_kernel_benchmark/convbench/conv_utils.py
@@ -48,6 +48,14 @@ class ConvConfig:
             + str(self.S)
         )
 
+    def __eq__(self, other):
+        if not isinstance(other, ConvConfig):
+            return NotImplemented
+        return self.get_name() == other.get_name()
+
+    def __hash__(self):
+        return hash(self.get_name())
+
     def get_img_shape(self) -> str:
         if "nhwc" in self.OP:
             in_h = self.H * self.S + self.P - 1
@@ -188,12 +196,19 @@ def generate_mlir(config: ConvConfig):
 
 
 def compile_conv_config(
-    config: ConvConfig, kernel_dir: Path, vmfb_dir: Path, extra_compiler_args: list[str]
+    tag: str,
+    config: ConvConfig,
+    kernel_dir: Path,
+    vmfb_dir: Path,
+    extra_compiler_args: list[str],
 ) -> tuple[Path, Optional[Path]]:
-    mlir_file = kernel_dir / (config.get_name() + ".mlir")
-    vmfb_file = vmfb_dir / (config.get_name() + ".vmfb")
-    dump_file = kernel_dir / (config.get_name() + ".stderr.mlir")
-    files_path = vmfb_dir / config.get_name()
+    # Name with tag is used for filenames so that duplicate configs with
+    # different tags will not clobber eachother.
+    name_with_tag = tag + "-" + config.get_name()
+    mlir_file = kernel_dir / (name_with_tag + ".mlir")
+    vmfb_file = vmfb_dir / (name_with_tag + ".vmfb")
+    dump_file = kernel_dir / (name_with_tag + ".stderr.mlir")
+    files_path = vmfb_dir / name_with_tag
 
     # Generate mlir content
     mlir_content = generate_mlir(config)

--- a/iree_kernel_benchmark/convbench/wave_conv_utils.py
+++ b/iree_kernel_benchmark/convbench/wave_conv_utils.py
@@ -25,14 +25,21 @@ else:
 
 
 def compile_wave_conv_config(
-    config: ConvConfig, kernel_dir: Path, vmfb_dir: Path, extra_compiler_args: list[str]
+    tag: str,
+    config: ConvConfig,
+    kernel_dir: Path,
+    vmfb_dir: Path,
+    extra_compiler_args: list[str],
 ) -> tuple[Path, Optional[Path]]:
     if not TURBINE_AVAILABLE:
         raise ValueError("iree.turbine package is not available")
 
-    mlir_file = kernel_dir / (config.get_name() + ".mlir")
-    vmfb_file = vmfb_dir / (config.get_name() + ".vmfb")
-    files_path = vmfb_dir / config.get_name()
+    # Name with tag is used for filenames so that duplicate configs with
+    # different tags will not clobber eachother.
+    name_with_tag = tag + "-" + config.get_name()
+    mlir_file = kernel_dir / (name_with_tag + ".mlir")
+    vmfb_file = vmfb_dir / (name_with_tag + ".vmfb")
+    files_path = vmfb_dir / name_with_tag
 
     try:
         _compile_conv(config, mlir_file, vmfb_file)


### PR DESCRIPTION
Achieved by:

- Deduplication of tag-config pairs in the list of configs. (To this end, equality and hashing support for configs is added.)
- Using different filenames when compiling the same config with different tags.

Fixes convbench CI failures caused by a race condition, and should also be a significant efficiency improvement (40% of tag-config pairs were duplicates).