### PR TITLE
Add --config_regex option to gemmbench to allow executing a subset

### DIFF
--- a/iree_kernel_benchmark/gemmbench/__main__.py
+++ b/iree_kernel_benchmark/gemmbench/__main__.py
@@ -76,6 +76,11 @@ if __name__ == "__main__":
         default=".*",
     )
     parser.add_argument(
+        "--config_regex",
+        help="Regular expression for allowed benchmark configurations. Defaults to all allowed.",
+        default=".*",
+    )
+    parser.add_argument(
         "--roofline",
         help="Comma separated csv file list to generate roofline plot with",
         default=None,
@@ -130,6 +135,7 @@ if __name__ == "__main__":
         requested_dtypes,
         requested_variants,
         args.tag_regex,
+        args.config_regex,
         args.raw_accumulators,
     )
     print(f"Generated {len(configs)} gemm configs.")

--- a/iree_kernel_benchmark/gemmbench/problems.py
+++ b/iree_kernel_benchmark/gemmbench/problems.py
@@ -1114,9 +1114,11 @@ def get_matching_configs(
     dtypes: list[str],
     variants: list[str],
     tag_regex: str,
+    config_regex: str,
     raw_accumulators: bool,
 ) -> list[tuple[str, GemmConfig]]:
     tag_re = re.compile(tag_regex)
+    config_re = re.compile(config_regex)
     matching_configs: list[tuple[str, GemmConfig]] = []
     for tag, config in tagged_configs:
         if config.operand_element_type not in dtypes:
@@ -1124,6 +1126,8 @@ def get_matching_configs(
         if f"{config.tA}{config.tB}" not in variants:
             continue
         if not tag_re.match(tag):
+            continue
+        if not config_re.match(config.get_name()):
             continue
         # The raw_accumulators arg means "test configs where the result element
         # type is different from what it would be in the default mode".


### PR DESCRIPTION
Essentially 759cd6f412250c9bcb09114a2d3b038966f166d7 but for gemmbench, also intended for debugging.