### PR TITLE
Fix TK gemmbench after renaming of tkw.reduction() to tkw.iterate()

### DIFF
--- a/iree_kernel_benchmark/gemmbench/gemm_utils.py
+++ b/iree_kernel_benchmark/gemmbench/gemm_utils.py
@@ -247,7 +247,7 @@ def generate_tk_mlir(config: GemmConfig, vmfb_file: Path):
 
         # This microkernel encodes the fact that if the reduction
         # dimension were tiled, then we would need to materialize a loop.
-        @tkw.reduction(K, init_args=[c_reg])
+        @tkw.iterate(K, init_args=[c_reg])
         def repeat(acc: tkl.Register[M, N, tkl.f32]) -> tkl.Register[M, N, tkl.f32]:
             # a_reg: tkw.Register[M, K, tkl.f16]
             a_reg = tkw.read(a, elements_per_thread=LOAD_ELEMS_PER_THREAD)


### PR DESCRIPTION
See https://github.com/iree-org/iree-turbine/commit/5cee489ec4418a8232cbbc43d4131ab181deffc4