### PR TITLE
gemmbench: Add support for four FP8 types and test one in CI

### DIFF
--- a/.github/workflows/run_bench.yml
+++ b/.github/workflows/run_bench.yml
@@ -56,6 +56,11 @@ jobs:
           source bench_venv/bin/activate
           python -m iree_kernel_benchmark.gemmbench --dtypes f16
 
+      - name: GEMM FP8 (f8E4M3FNUZ)
+        run: |
+          source bench_venv/bin/activate
+          python -m iree_kernel_benchmark.gemmbench --dtypes f8E4M3FNUZ
+
       - name: GEMM I8
         run: |
           source bench_venv/bin/activate

--- a/iree_kernel_benchmark/gemmbench/__main__.py
+++ b/iree_kernel_benchmark/gemmbench/__main__.py
@@ -62,7 +62,7 @@ if __name__ == "__main__":
         "--dtypes",
         nargs="+",
         default=[],
-        help="List of data types to generate benchmarks for. Defaults to f16. Other options include f32, bf16, i8.",
+        help="List of data types to generate benchmarks for. Defaults to f16. Other options include (for example) f32, bf16, i8, f8E4M3FNUZ.",
     )
     parser.add_argument(
         "--raw_accumulators",

--- a/iree_kernel_benchmark/gemmbench/problems.py
+++ b/iree_kernel_benchmark/gemmbench/problems.py
@@ -4,19 +4,23 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from .gemm_utils import GemmConfig
+from .gemm_utils import GemmConfig, num_bytes
 
 import re
 
 
-def num_bytes(dtype: str) -> int:
-    return {"f16": 2, "bf16": 2, "f32": 4, "i8": 1, "i32": 4}[dtype]
-
-
 def get_default_accumulator_element_type(operand_element_type: str) -> str:
-    return {"f16": "f32", "bf16": "f32", "f32": "f32", "i8": "i32", "i32": "i32"}[
-        operand_element_type
-    ]
+    return {
+        "f16": "f32",
+        "bf16": "f32",
+        "f32": "f32",
+        "f8E4M3FNUZ": "f32",
+        "f8E5M2FNUZ": "f32",
+        "f8E4M3FN": "f32",
+        "f8E5M2": "f32",
+        "i8": "i32",
+        "i32": "i32",
+    }[operand_element_type]
 
 
 def get_default_result_element_type(


### PR DESCRIPTION
The added types are ones supported by both MLIR and IREE, and with some AMD GPU support: f8E4M3FNUZ and f8E5M2FNUZ are supported on CDNA3, whereas f8E4M3FN and f8E5M2 are supported on RDNA4. f8E4M3FNUZ is tested in CI (on MI300).