### PR TITLE
Migrate existing mi300 runners to new mi325 capacity.

### DIFF
--- a/.github/workflows/run_bench.yml
+++ b/.github/workflows/run_bench.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   benchmark:
-    runs-on: linux-mi300-1gpu-ossci-nod-ai
+    runs-on: linux-mi325-1gpu-ossci-nod-ai
 
     steps:
       - name: "Checkout Repo"

--- a/.github/workflows/short_bench.yml
+++ b/.github/workflows/short_bench.yml
@@ -32,7 +32,7 @@ concurrency:
 
 jobs:
   short_benchmark:
-    runs-on: linux-mi300-1gpu-ossci-nod-ai
+    runs-on: linux-mi325-1gpu-ossci-nod-ai
 
     env:
       ITERATIONS: ${{ inputs.iterations || '3' }}


### PR DESCRIPTION
Runner capacity is shifting from MI300 to MI325 machines. These machines are compatible enough for testing, though benchmarks will need new baselines.